### PR TITLE
refactor(getQueryStringParam): Escape all regex special characters in…

### DIFF
--- a/src/get-query-string-param.js
+++ b/src/get-query-string-param.js
@@ -10,9 +10,8 @@ export default getQueryStringParam
  * @return {String} - the value
  */
 function getQueryStringParam(url, name) {
-  const regexReadyName = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]')
+  const regexReadyName = name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
   const regex = new RegExp('[\\?&]' + regexReadyName + '=([^&#]*)')
   const results = regex.exec(url)
   return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '))
 }
-


### PR DESCRIPTION
… the name parameter.

Currently the method is escaping only for the "[" and "]". The main idea is to escape all special characters that can be used in the regex expression itself. 