### PR TITLE
Simplified getObjectSize

### DIFF
--- a/src/get-object-size.js
+++ b/src/get-object-size.js
@@ -11,9 +11,5 @@ export default getObjectSize
  * */
 
 function getObjectSize(obj) {
-  if (Array.isArray(obj)) {
-    return obj.length
-  } else {
-    return Object.keys(obj).length
-  }
+  return Object.keys(obj).length
 }


### PR DESCRIPTION
As far as I can tell, `Object.keys(..)` works on an array, which makes the array test unnecessary. 