### PR TITLE
feat(hex2rgb): Add a function that converts colors in Hex to RGB format

### DIFF
--- a/src/hex2rgb.js
+++ b/src/hex2rgb.js
@@ -1,0 +1,24 @@
+export default hex2rgb
+
+/**
+ * Original Source: http://stackoverflow.com/a/12342275
+ *
+ * This method will convert colors in Hex to RGB format.
+ *
+ * @param {String} hex - The Hex value to be converted
+ * @param {Number} opacity - The opacity value of the color
+ * @return {String} - The RGB value of the color
+ */
+function hex2rgb(hex, opacity) {
+  let h = hex.replace('#', '')
+  h = h.match(new RegExp(`(.{${h.length / 3}})`, 'g'))
+
+  for (let i = 0; i < h.length; i++) {
+    h[i] = parseInt(h[i].length === 1 ? h[i] + h[i] : h[i], 16)
+  }
+  if (typeof opacity !== 'undefined') {
+    h.push(opacity)
+  }
+
+  return `rgba(${h.join(',')})`
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import objectValuesToString from './object-values-to-string'
 import getObjectSize from './get-object-size'
 import isArray from './is-array'
 import validateEmail from './validateEmail'
+import hex2rgb from './hex2rgb'
 
 export {
   flatten,
@@ -22,4 +23,5 @@ export {
   getObjectSize,
   isArray,
   validateEmail,
+  hex2rgb,
 }

--- a/test/hex2rgb.test.js
+++ b/test/hex2rgb.test.js
@@ -1,0 +1,24 @@
+import test from 'ava'
+import {hex2rgb} from '../src'
+
+test('test hex without opacity value', t=>{
+  const hex = '#ff0000'
+  const expected = 'rgba(255,0,0)'
+  const actual = hex2rgb(hex)
+  t.deepEqual(actual, expected)
+})
+
+test('test hex with opacity value', t=>{
+  const hex = '#ff0000'
+  const opacity = 1
+  const expected = 'rgba(255,0,0,1)'
+  const actual = hex2rgb(hex,opacity)
+  t.deepEqual(actual,expected)
+})
+
+test('test short hex without opacity value', t=>{
+  const hex = '#f00'
+  const expected = 'rgba(255,0,0)'
+  const actual = hex2rgb(hex)
+  t.deepEqual(actual, expected)
+})


### PR DESCRIPTION
Function accepts both `#fff` and `#ffffff` variants. Opacity can be omitted as well.

#43