### PR TITLE
enhacement(dec2hex): js + test

### DIFF
--- a/src/dec2hex.js
+++ b/src/dec2hex.js
@@ -1,0 +1,14 @@
+export default dec2hex
+
+/**
+ * Original source: https://stackoverflow.com/questions/57803/how-to-convert-decimal-to-hex-in-javascript
+ * This method will return the Hex equivalent or any num
+ * However the native function can only handle Number.MAX_SAFE_INTEGER => 9007199254740991
+ * @param {Number} num - the array to calculate average
+ * @return {String} - String with Hex value
+ */
+
+function dec2hex(num) {
+  const hextString = num.toString(16)
+  return hextString
+}

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import multiply from './multiply'
 import square from './square'
 import cube from './cube'
 import sum from './sum'
+import dec2hex from './dec2hex'
 import dec2bin from './dec2bin'
 import searchAndReplace from './search-and-replace'
 import sqrt from './sqrt'
@@ -150,4 +151,5 @@ export {
   curry,
   textJustification,
   removeProperty,
+  dec2hex,
 }

--- a/test/dec2hex.test.js
+++ b/test/dec2hex.test.js
@@ -1,0 +1,9 @@
+import test from 'ava'
+import {dec2hex} from '../src'
+
+test('Simple Conversion', t => {
+  const number = 60
+  const expected = '3c'
+  const actual = dec2hex(number)
+  t.deepEqual(actual, expected)
+})


### PR DESCRIPTION
@kentcdodds
The function and test were stright forward, however, I am gettting a strange error, confirmed by `eslint`: `[eslint] dec2hex not found in '../src'` 

So when I run the test, it fails because it is not finding the module. I tried adding another `.js` module, and odd enough I was getting the same issue.

I also tried default import like `import dec2hex from '../src'` but then I get 
`[eslint] No default export found in module.` which makes sense if the module is not found

I ran `npm run lint` did not get any linting errors, and after ran a `npm build` too, but I was not able to solve it. 

Can you please provide a guide so I can make the test run and be able to make the PR

Many thanks!!!!